### PR TITLE
Add simple caching on NSCache

### DIFF
--- a/CountriesSwiftUI/Services/ImagesService.swift
+++ b/CountriesSwiftUI/Services/ImagesService.swift
@@ -14,25 +14,43 @@ protocol ImagesService {
     func load(image: LoadableSubject<UIImage>, url: URL?)
 }
 
+struct ImageCache {
+    private let cache = NSCache<NSURL, UIImage>()
+
+    subscript(_ key: URL) -> UIImage? {
+        get { cache.object(forKey: key as NSURL) }
+        set { newValue == nil ? cache.removeObject(forKey: key as NSURL) : cache.setObject(newValue!, forKey: key as NSURL) }
+    }
+}
+
 struct RealImagesService: ImagesService {
-    
+
     let webRepository: ImageWebRepository
-    
+    var imageCache: ImageCache
+
     init(webRepository: ImageWebRepository) {
         self.webRepository = webRepository
+        self.imageCache = ImageCache()
     }
-    
+
     func load(image: LoadableSubject<UIImage>, url: URL?) {
         guard let url = url else {
             image.wrappedValue = .notRequested; return
         }
         let cancelBag = CancelBag()
-        image.wrappedValue = .isLoading(last: image.wrappedValue.value, cancelBag: cancelBag)
-        webRepository.load(imageURL: url, width: 300)
-            .sinkToLoadable {
-                image.wrappedValue = $0
+        if let caсhedImage = imageCache[url] {
+            image.wrappedValue = .loaded(caсhedImage)
+        }
+        else {
+            image.wrappedValue = .isLoading(last: image.wrappedValue.value, cancelBag: cancelBag)
+            var cache = self.imageCache
+            webRepository.load(imageURL: url, width: 300)
+                .sinkToLoadable {
+                    image.wrappedValue = $0
+                    cache[url] = $0.value
             }
             .store(in: cancelBag)
+        }
     }
 }
 

--- a/CountriesSwiftUI/System/AppDelegate.swift
+++ b/CountriesSwiftUI/System/AppDelegate.swift
@@ -21,6 +21,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions
         launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        URLCache.shared.removeAllCachedResponses()
         return true
     }
     


### PR DESCRIPTION
Hi Alexander, thanks for your work.

I noticed a strange behavior here: when I exit the modal window, the flag picture reloaded every time, which doesn’t look beautiful. And I decided to try adding image caching to your implementation. It turned out quite primitive, but it works. If you like it, you can add.

Although in reality most likely you need to solve another problem so that the View with the flag does not restart after exiting the modal window, since it is already on the stack, but it is most likely much more complicated.

Sincerely, Andrey Shcherbinin.