### PR TITLE
:bug: Avoid retain instances of VM on memory

### DIFF
--- a/CountriesSwiftUI.xcodeproj/project.pbxproj
+++ b/CountriesSwiftUI.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		52333A932654463B0034072B /* UIOpenURLContext_Init.m in Sources */ = {isa = PBXBuildFile; fileRef = 52333A922654463B0034072B /* UIOpenURLContext_Init.m */; };
+		678E0BAF26B749A000B21166 /* Publisher+WeakAssign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 678E0BAE26B749A000B21166 /* Publisher+WeakAssign.swift */; };
 		F60829712369CE0100DB292E /* RequestMocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60829702369CE0100DB292E /* RequestMocking.swift */; };
 		F60829732369CE5300DB292E /* MockedResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60829722369CE5300DB292E /* MockedResponse.swift */; };
 		F60829762369D58A00DB292E /* CountriesWebRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60829752369D58A00DB292E /* CountriesWebRepositoryTests.swift */; };
@@ -110,6 +111,7 @@
 		52333A90265445F30034072B /* UnitTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UnitTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		52333A91265445F30034072B /* UIOpenURLContext_Init.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIOpenURLContext_Init.h; sourceTree = "<group>"; };
 		52333A922654463B0034072B /* UIOpenURLContext_Init.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UIOpenURLContext_Init.m; sourceTree = "<group>"; };
+		678E0BAE26B749A000B21166 /* Publisher+WeakAssign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WeakAssign.swift"; sourceTree = "<group>"; };
 		F60829702369CE0100DB292E /* RequestMocking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestMocking.swift; sourceTree = "<group>"; };
 		F60829722369CE5300DB292E /* MockedResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockedResponse.swift; sourceTree = "<group>"; };
 		F60829752369D58A00DB292E /* CountriesWebRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountriesWebRepositoryTests.swift; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 				F644960D2360EF6C00C9BB1F /* WebRepository.swift */,
 				F60B5E402438DAF6009BCBB3 /* NetworkingHelpers.swift */,
 				F661F2CB23783E360014E142 /* Helpers.swift */,
+				678E0BAE26B749A000B21166 /* Publisher+WeakAssign.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -681,6 +684,7 @@
 				F64495E72360D66400C9BB1F /* SceneDelegate.swift in Sources */,
 				F67F62B52443276000A6ED11 /* Models+CoreData.swift in Sources */,
 				F64495E92360D66400C9BB1F /* ContentView.swift in Sources */,
+				678E0BAF26B749A000B21166 /* Publisher+WeakAssign.swift in Sources */,
 				F67DBD652368875A00C83258 /* CountriesWebRepository.swift in Sources */,
 				F644960C2360EAD000C9BB1F /* APICall.swift in Sources */,
 				F64496122361BB4900C9BB1F /* ServicesContainer.swift in Sources */,

--- a/CountriesSwiftUI/UI/RootViewModifier.swift
+++ b/CountriesSwiftUI/UI/RootViewModifier.swift
@@ -32,7 +32,7 @@ extension RootViewAppearance {
         init(container: DIContainer) {
             container.appState.map(\.system.isActive)
                 .removeDuplicates()
-                .assign(to: \.isActive, on: self)
+                .weakAssign(to: \.isActive, on: self)
                 .store(in: cancelBag)
         }
     }

--- a/CountriesSwiftUI/UI/Screens/CountriesList/CountriesListViewModel.swift
+++ b/CountriesSwiftUI/UI/Screens/CountriesList/CountriesListViewModel.swift
@@ -52,10 +52,10 @@ extension CountriesList {
                     .sink { appState[\.routing.countriesList] = $0 }
                 appState.map(\.routing.countriesList)
                     .removeDuplicates()
-                    .assign(to: \.routingState, on: self)
+                    .weakAssign(to: \.routingState, on: self)
                 appState.updates(for: AppState.permissionKeyPath(for: .pushNotifications))
                     .map { $0 == .notRequested || $0 == .denied }
-                    .assign(to: \.canRequestPushPermission, on: self)
+                    .weakAssign(to: \.canRequestPushPermission, on: self)
             }
         }
         

--- a/CountriesSwiftUI/UI/Screens/CountryDetails/CountryDetailsViewModel.swift
+++ b/CountriesSwiftUI/UI/Screens/CountryDetails/CountryDetailsViewModel.swift
@@ -43,7 +43,7 @@ extension CountryDetails {
                     .sink { appState[\.routing.countryDetails] = $0 }
                 appState.map(\.routing.countryDetails)
                     .removeDuplicates()
-                    .assign(to: \.routingState, on: self)
+                    .weakAssign(to: \.routingState, on: self)
             }
         }
         

--- a/CountriesSwiftUI/Utilities/Publisher+WeakAssign.swift
+++ b/CountriesSwiftUI/Utilities/Publisher+WeakAssign.swift
@@ -1,0 +1,21 @@
+//
+//  Publisher+WeakAssign.swift
+//  CountriesSwiftUI
+//
+//  Created by Amadeu Cavalcante on 01/08/21.
+//  Copyright © 2021 Alexey Naumov. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+extension Publisher where Failure == Never {
+    func weakAssign<T: AnyObject>(
+        to keyPath: ReferenceWritableKeyPath<T, Output>,
+        on object: T
+    ) -> AnyCancellable {
+        sink { [weak object] value in
+            object?[keyPath: keyPath] = value
+        }
+    }
+}


### PR DESCRIPTION
The VM's were being held on memory even after the screen has be removed from the navigation.