### PR TITLE
fix: simplify self

### DIFF
--- a/CountriesSwiftUI/Persistence/CoreDataHelpers.swift
+++ b/CountriesSwiftUI/Persistence/CoreDataHelpers.swift
@@ -16,7 +16,7 @@ protocol ManagedEntity: NSFetchRequestResult { }
 extension ManagedEntity where Self: NSManagedObject {
     
     static var entityName: String {
-        let nameMO = String(describing: Self.self)
+        let nameMO = String(describing: self)
         let suffixIndex = nameMO.index(nameMO.endIndex, offsetBy: -2)
         return String(nameMO[..<suffixIndex])
     }


### PR DESCRIPTION
Hello, I found out that the entityName variable in the ManagedEntity protocol points to itself. This may be a difference in taste. 
But how about fixing it like this?