### PR TITLE
fix: change baseURL to v3.1

### DIFF
--- a/CountriesSwiftUI/Repositories/WebAPI/CountriesWebRepository.swift
+++ b/CountriesSwiftUI/Repositories/WebAPI/CountriesWebRepository.swift
@@ -20,7 +20,7 @@ struct RealCountriesWebRepository: CountriesWebRepository {
 
     init(session: URLSession) {
         self.session = session
-        self.baseURL = "https://restcountries.com/v2"
+        self.baseURL = "https://restcountries.com/v3.1"
     }
 
     func countries() async throws -> [ApiModel.Country] {


### PR DESCRIPTION
should used v3.1 to get the latest country information

<img width="533" alt="image" src="https://github.com/user-attachments/assets/b3df48c7-980a-42a0-9111-93ca95c94efe" />

> https://restcountries.com/