### PR TITLE
feat: add Package.swift file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,52 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "CountriesSwiftUI",
+    platforms: [
+        .iOS(.v18),
+        .macOS(.v12)
+    ],
+    products: [
+        .library(name: "CountriesSwiftUI", targets: ["CountriesSwiftUI"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/nalexn/EnvironmentOverrides", from: "0.0.4"),
+        .package(url: "https://github.com/nalexn/ViewInspector", from: "0.10.0")
+    ],
+    targets: [
+        .target(
+            name: "CountriesSwiftUI",
+            dependencies: [
+                .product(name: "EnvironmentOverrides", package: "EnvironmentOverrides")
+            ],
+            path: "CountriesSwiftUI",
+            exclude: [
+                "Resources/Preview Assets.xcassets",
+            ],
+            resources: [
+                .process("Resources/Assets.xcassets"),
+                .process("Resources/Localizable.xcstrings"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ],
+            linkerSettings: [
+                .linkedFramework("UIKit")
+            ]
+        ),
+        .testTarget(
+            name: "UnitTests",
+            dependencies: [
+                "CountriesSwiftUI",
+                .product(name: "ViewInspector", package: "ViewInspector")
+            ],
+            path: "UnitTests",
+            swiftSettings: [
+                .swiftLanguageMode(.v5)
+            ],
+        )
+    ]
+)


### PR DESCRIPTION
add Package.swift file, and we can open this repo on VSCode with Swift Extension

In order to make code completion and jump to definition features enabled:
- use latest version of Swift Extension(current version is 2.2.0)
- make sure Swift version is equal to or greater than 6.1
- use command `Swift: Select Target Platform...` to select iOS sdk