### PR TITLE
Quick fix for the new API rule for \all route

### DIFF
--- a/CountriesSwiftUI/Repositories/Database/CountriesDBRepository.swift
+++ b/CountriesSwiftUI/Repositories/Database/CountriesDBRepository.swift
@@ -41,8 +41,8 @@ extension MainDBRepository: CountriesDBRepository {
         let alpha3Code = country.alpha3Code
         try modelContext.transaction {
             let currencies = countryDetails.currencies.map { $0.dbModel() }
-            let neighborsFetch = FetchDescriptor(predicate: #Predicate<DBModel.Country> {
-                countryDetails.borders.contains($0.alpha3Code)
+            let neighborsFetch = FetchDescriptor(predicate: #Predicate<DBModel.Country> { countryDBModel in
+                countryDetails.borders?.contains(countryDBModel.alpha3Code) == true
             })
             let neighbors = try modelContext.fetch(neighborsFetch)
             currencies.forEach {

--- a/CountriesSwiftUI/Repositories/Models/CountryDetails.swift
+++ b/CountriesSwiftUI/Repositories/Models/CountryDetails.swift
@@ -16,7 +16,7 @@ extension DBModel {
         @Attribute(.unique) var alpha3Code: String
         var capital: String
         var currencies: [Currency]
-        var neighbors: [Country]
+        var neighbors: [Country]?
 
         init(alpha3Code: String, capital: String, currencies: [Currency], neighbors: [Country]) {
             self.alpha3Code = alpha3Code
@@ -33,6 +33,6 @@ extension ApiModel {
     struct CountryDetails: Codable, Equatable {
         let capital: String
         let currencies: [Currency]
-        let borders: [String]
+        let borders: [String]?
     }
 }

--- a/CountriesSwiftUI/Repositories/WebAPI/CountriesWebRepository.swift
+++ b/CountriesSwiftUI/Repositories/WebAPI/CountriesWebRepository.swift
@@ -49,7 +49,7 @@ extension RealCountriesWebRepository.API: APICall {
     var path: String {
         switch self {
         case .allCountries:
-            return "/all"
+            return "/all?fields=name,translations,population,flag,alpha3Code"
         case let .countryDetails(countryName):
             let encodedName = countryName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
             return "/name/\(encodedName ?? countryName)"

--- a/CountriesSwiftUI/UI/CountryDetails/CountryDetailsView.swift
+++ b/CountriesSwiftUI/UI/CountryDetails/CountryDetailsView.swift
@@ -105,8 +105,10 @@ private extension CountryDetails {
             if countryDetails.currencies.count > 0 {
                 currenciesSectionView(currencies: countryDetails.currencies)
             }
-            if countryDetails.neighbors.count > 0 {
-                neighborsSectionView(neighbors: countryDetails.neighbors)
+            if let neighbors = countryDetails.neighbors {
+                if neighbors.count  > 0 {
+                    neighborsSectionView(neighbors: neighbors)
+                }
             }
         }
         .listStyle(GroupedListStyle())


### PR DESCRIPTION
The API provider recently enforced [adding fields to the \all endpoint](https://gitlab.com/restcountries/restcountries/-/issues/265). This PR fixes the issue by adding the necessary fields to the all countries endpoint.

In addition, the endpoint \name does not always return the borders for the country which causes the country view to break in the app - I don't know if this is new or not. The PR addresses this issue by making the relevant types optional.
